### PR TITLE
fix: 修复 visit_ClassDef 方法中的方法调用错误

### DIFF
--- a/scripts/advanced_merge.py
+++ b/scripts/advanced_merge.py
@@ -480,13 +480,13 @@ class ContextAwareVisitor(ast.NodeVisitor):
         
         # 处理装饰器
         for decorator in node.decorator_list:
-            decorator_symbols = self.collect_dependencies_from_node(decorator)
+            decorator_symbols = self.analyze_dependencies(decorator)
             symbol.decorators.extend(decorator_symbols)
             symbol.dependencies.update(decorator_symbols)
             
         # 处理基类
         for base in node.bases:
-            base_symbols = self.collect_dependencies_from_node(base)
+            base_symbols = self.analyze_dependencies(base)
             symbol.dependencies.update(base_symbols)
             
         # 注册符号


### PR DESCRIPTION
## 问题描述
- `visit_ClassDef` 方法中调用了不存在的方法 `collect_dependencies_from_node()`
- 导致装饰器和基类依赖分析失败

## 修复内容
- 将第483行的 `self.collect_dependencies_from_node(decorator)` 改为 `self.analyze_dependencies(decorator)`
- 将第489行的 `self.collect_dependencies_from_node(base)` 改为 `self.analyze_dependencies(base)`

## 验证结果
- ✅ 语法检查通过
- ✅ 模块正常加载
- ✅ 示例测试运行成功
- ✅ 输出结果与原始脚本一致
- ✅ 确认项目中无残留的错误方法调用

🤖 Generated with [Claude Code](https://claude.ai/code)