### PR TITLE
fix: 修复模块作用域污染导致的命名空间错误问题

### DIFF
--- a/scripts/advanced_merge.py
+++ b/scripts/advanced_merge.py
@@ -194,7 +194,11 @@ class ContextAwareVisitor(ast.NodeVisitor):
         """分析单个模块"""
         if module_path in self.analyzed_modules:
             return
-            
+        
+        # --- 保存现场（新增） ---
+        _prev_module_path = getattr(self, "current_module_path", None)
+        # -----------------------
+        
         self.analyzed_modules.add(module_path)
         self.current_module_path = module_path
         
@@ -216,6 +220,10 @@ class ContextAwareVisitor(ast.NodeVisitor):
         self.push_scope(module_scope)
         self.visit(tree)
         self.pop_scope()
+        
+        # --- 恢复现场（新增） ---
+        self.current_module_path = _prev_module_path
+        # -----------------------
         
     def visit_Module(self, node: ast.Module):
         """访问模块节点"""


### PR DESCRIPTION
## Summary
- 修复了 `ContextAwareVisitor` 在分析多个模块时 `current_module_path` 状态污染的问题
- 通过保存和恢复现场机制，确保模块分析的独立性
- 解决了处理复杂多模块依赖时可能出现的属性查找错误

## Test plan
- [x] 运行现有测试套件，确保所有测试通过
- [x] 手动测试多模块依赖场景，验证修复效果
- [x] 确认不会引入新的回归问题

🤖 Generated with [Claude Code](https://claude.ai/code)